### PR TITLE
added latest elasticsearch version (7.4.0)

### DIFF
--- a/ariadna-docker/docker-compose.yml
+++ b/ariadna-docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - ariadna-net
 
   ariadna-es:
-    image: elasticsearch
+    image: elasticsearch:7.4.0
     restart: always
     ports:
       - 9200:9200


### PR DESCRIPTION
Fixes below error:
```
Pulling ariadna-es (elasticsearch:latest)...
ERROR: manifest for elasticsearch:latest not found
```